### PR TITLE
Implement basic DHT peer discovery

### DIFF
--- a/rytorr/Cargo.toml
+++ b/rytorr/Cargo.toml
@@ -23,3 +23,4 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 futures = "0.3.31"
 async-trait = "0.1.88"
 crossterm = "0.29.0"
+mainline = { version = "5.4.0", features = ["async"] }

--- a/rytorr/src/dht.rs
+++ b/rytorr/src/dht.rs
@@ -1,0 +1,35 @@
+use futures::StreamExt;
+use mainline::{async_dht::AsyncDht, Id, Dht};
+use std::net::SocketAddrV4;
+
+/// Wrapper around the [`mainline`] DHT implementation.
+#[derive(Debug)]
+pub struct DhtNode {
+    dht: AsyncDht,
+}
+
+impl DhtNode {
+    /// Create a new DHT node in client mode and wait for bootstrapping.
+    pub async fn new() -> std::io::Result<Self> {
+        let dht = Dht::client()?.as_async();
+        dht.bootstrapped().await;
+        Ok(Self { dht })
+    }
+
+    /// Announce ourselves for the given info hash and port.
+    pub async fn announce(&self, info_hash: [u8; 20], port: u16) {
+        let id = Id::from_bytes(info_hash).expect("info hash has invalid length");
+        let _ = self.dht.announce_peer(id, Some(port)).await;
+    }
+
+    /// Query the DHT for peers for the given info hash.
+    pub async fn get_peers(&self, info_hash: [u8; 20]) -> Vec<SocketAddrV4> {
+        let id = Id::from_bytes(info_hash).expect("info hash has invalid length");
+        let mut stream = self.dht.get_peers(id);
+        let mut result = Vec::new();
+        while let Some(mut peers) = stream.next().await {
+            result.append(&mut peers);
+        }
+        result
+    }
+}

--- a/rytorr/src/engine.rs
+++ b/rytorr/src/engine.rs
@@ -11,6 +11,7 @@ use torrex::bencode::Torrent;
 
 use crate::{
     peer::Peer,
+    dht::DhtNode,
     status,
     swarm::{PeerMapArc, Swarm, SwarmArgs, SwarmConfig},
     tracker::{http, udp, Trackable, TrackerType},
@@ -308,6 +309,38 @@ impl TorrentClient {
         }
     }
 
+    pub fn start_dht(&self) {
+        const DHT_QUERY_INTERVAL_SECS: u64 = 300;
+
+        let info_hash = self.torrent.info.hash;
+        let sender = self.peer_sender.clone();
+        let port = self.port;
+
+        tokio::spawn(async move {
+            let dht = match DhtNode::new().await {
+                Ok(d) => d,
+                Err(e) => {
+                    error!(error = %e, "Failed to start DHT node");
+                    return;
+                }
+            };
+
+            dht.announce(info_hash, port).await;
+
+            loop {
+                let peers = dht.get_peers(info_hash).await;
+                for addr in peers {
+                    let sock = std::net::SocketAddr::V4(addr);
+                    let peer = Peer::from_socket_address(sock);
+                    if let Err(e) = sender.send(PendingPeer::Outgoing(peer)).await {
+                        error!(error = %e, "Failed to send DHT peer to swarm");
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(DHT_QUERY_INTERVAL_SECS)).await;
+            }
+        });
+    }
+
     fn create_tracker(
         url: String,
         info_hash: Arc<Vec<u8>>,
@@ -357,6 +390,7 @@ impl Engine {
             .insert(info_hash, client.clone());
 
         client.start_tracking();
+        client.start_dht();
 
         Ok(())
     }

--- a/rytorr/src/main.rs
+++ b/rytorr/src/main.rs
@@ -4,6 +4,7 @@ mod peer;
 mod status;
 mod swarm;
 mod tracker;
+mod dht;
 
 use engine::Engine;
 use std::{env, process};

--- a/rytorr/src/peer.rs
+++ b/rytorr/src/peer.rs
@@ -336,7 +336,10 @@ impl PeerConnection {
         let mut buf = [0u8; 49 + Self::PSTR.len()];
         buf[0] = Self::PSTR.len() as u8;
         buf[1..(1 + Self::PSTR.len())].copy_from_slice(Self::PSTR.as_bytes());
-        buf[(1 + Self::PSTR.len())..(1 + Self::PSTR.len() + 8)].copy_from_slice(&[0u8; 8]); // Reserved 8 bytes
+        let mut reserved = [0u8; 8];
+        // Indicate DHT support by setting the last bit of the reserved field (BEP 0005)
+        reserved[7] |= 0x01;
+        buf[(1 + Self::PSTR.len())..(1 + Self::PSTR.len() + 8)].copy_from_slice(&reserved);
         buf[(1 + Self::PSTR.len() + 8)..(1 + Self::PSTR.len() + 8 + info_hash.len())]
             .copy_from_slice(info_hash); // Info hash 20 bytes
         buf[(1 + Self::PSTR.len() + 8 + info_hash.len())


### PR DESCRIPTION
## Summary
- introduce `DhtNode` wrapper for the `mainline` crate
- integrate DHT peer discovery into `TorrentClient`
- update CLI to include the new module
- add `mainline` dependency
- advertise DHT support in peer handshakes

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6858d30486dc83329ec0985947442e42